### PR TITLE
Updated uuid.NewV4 to comply with upstream API changes

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -48,7 +48,7 @@ func StartDiscovery(duration time.Duration) ([]Device, error) {
 
 func discoverDevices(ipAddr string, duration time.Duration) ([]Device, error) {
 	// Create WS-Discovery request
-	requestID := "uuid:" + uuid.NewV4().String()
+	requestID := "uuid:" + uuid.Must(uuid.NewV4()).String()
 	request := `		
 		<?xml version="1.0" encoding="UTF-8"?>
 		<e:Envelope

--- a/soap.go
+++ b/soap.go
@@ -105,7 +105,7 @@ func (soap SOAP) createRequest() string {
 }
 
 func (soap SOAP) createUserToken() string {
-	nonce := uuid.NewV4().Bytes()
+	nonce := uuid.Must(uuid.NewV4()).Bytes()
 	nonce64 := base64.StdEncoding.EncodeToString(nonce)
 	timestamp := time.Now().Add(soap.TokenAge).UTC().Format(time.RFC3339)
 	token := string(nonce) + timestamp + soap.Password


### PR DESCRIPTION
Currently, when using go get to install the package, it will fail because of uuid package updates. This PR fixes the method used in go-onvif to comply with new changes.